### PR TITLE
Require nikic/php-parser 4.17 minimum

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
     },
     "require": {
         "php": "^8.1 | ^8.2 | ^8.3",
-        "nikic/php-parser": "^4.0",
+        "nikic/php-parser": "^4.17",
         "pmjones/auto-shell": "^1.0"
     },
     "require-dev": {


### PR DESCRIPTION
The printer references the `$type` property on `ClassConst`, which is only present from php-parser 4.17.

When I tried running php-styler for the first time, I saw many warnings like this:

```
Warning: Undefined property: PhpParser\Node\Stmt\ClassConst::$type
```

It was because my project was not using `nikic/php-parser` 4.17.